### PR TITLE
Refactored coroutines usage to enforce Main safety on KSP api's

### DIFF
--- a/Stratify.Test/src/main/kotlin/test/stratify/StratifySampleProcessor.kt
+++ b/Stratify.Test/src/main/kotlin/test/stratify/StratifySampleProcessor.kt
@@ -1,12 +1,8 @@
 package test.stratify
 
-import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
-import com.google.devtools.ksp.symbol.KSAnnotated
-import com.google.devtools.ksp.symbol.KSNode
+import io.github.mattshoe.shoebox.stratify.kspwrappers.StratifyResolver
 import io.github.mattshoe.shoebox.stratify.strategy.AnnotationStrategy
 import io.github.mattshoe.shoebox.stratify.StratifySymbolProcessor
-import io.github.mattshoe.shoebox.stratify.strategy.Strategy
 import test.stratify.annotation.DocReader
 import test.stratify.processors.DocReaderClassProcessor
 import test.stratify.processors.DocReaderFunctionProcessor
@@ -22,7 +18,7 @@ import test.stratify.processors.DocReaderFunctionProcessor
  *     which will return the KDoc of the annotated method.
  */
 class StratifySampleProcessor: StratifySymbolProcessor() {
-    override suspend fun buildStrategies(resolver: Resolver) = listOf(
+    override suspend fun buildStrategies(resolver: StratifyResolver) = listOf(
         AnnotationStrategy(
             annotation = DocReader::class,
             DocReaderClassProcessor(),

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/dispatchers/StratifyDispatcher.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/dispatchers/StratifyDispatcher.kt
@@ -1,0 +1,18 @@
+package io.github.mattshoe.shoebox.stratify.dispatchers
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
+
+object StratifyDispatcher {
+    /**
+     * You MUST use this dispatcher while accessing any KSP APIs. KSP is not thread-safe by
+     * default, so you must ensure that any operations you invoke on any KSP API runs on the
+     * Main thread.
+     *
+     * You do not need to use [StratifyDispatcher.Main] for processing and running your own code,
+     * you are only responsible for making sure any KSP APIs are invoked on [StratifyDispatcher.Main].
+     */
+    val Main: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+}
+

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/kspwrappers/DeprecatedCodeGenerator.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/kspwrappers/DeprecatedCodeGenerator.kt
@@ -1,0 +1,39 @@
+package io.github.mattshoe.shoebox.stratify.kspwrappers
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import java.io.File
+import java.io.OutputStream
+
+class DeprecatedCodeGenerator: CodeGenerator {
+    private val errorMessage = "You cannot use `SymbolProcessorEnvironment.codeGenerator`, you must use `StratifySymbolProcessor.codeGenerator` instead."
+
+    override val generatedFile: Collection<File>
+        get() = throw IllegalAccessException(errorMessage)
+
+    override fun associate(sources: List<KSFile>, packageName: String, fileName: String, extensionName: String)
+            = throw IllegalAccessException(errorMessage)
+
+    override fun associateByPath(sources: List<KSFile>, path: String, extensionName: String)
+            = throw IllegalAccessException(errorMessage)
+
+    override fun associateWithClasses(
+        classes: List<KSClassDeclaration>,
+        packageName: String,
+        fileName: String,
+        extensionName: String
+    )  = throw IllegalAccessException(errorMessage)
+
+    override fun createNewFile(
+        dependencies: Dependencies,
+        packageName: String,
+        fileName: String,
+        extensionName: String
+    ): OutputStream = throw IllegalAccessException(errorMessage)
+
+    override fun createNewFileByPath(dependencies: Dependencies, path: String, extensionName: String): OutputStream
+            = throw IllegalAccessException(errorMessage)
+
+}

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/kspwrappers/StratifyCodeGenerator.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/kspwrappers/StratifyCodeGenerator.kt
@@ -1,0 +1,13 @@
+package io.github.mattshoe.shoebox.stratify.kspwrappers
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import io.github.mattshoe.shoebox.stratify.dispatchers.StratifyDispatcher
+import kotlinx.coroutines.withContext
+
+class StratifyCodeGenerator(
+    private val codeGenerator: CodeGenerator
+) {
+    suspend fun <T> use(action: CodeGenerator.() -> T): T = withContext(StratifyDispatcher.Main) {
+        return@withContext codeGenerator.action()
+    }
+}

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/kspwrappers/StratifyResolver.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/kspwrappers/StratifyResolver.kt
@@ -1,0 +1,17 @@
+package io.github.mattshoe.shoebox.stratify.kspwrappers
+
+import com.google.devtools.ksp.processing.Resolver
+import io.github.mattshoe.shoebox.stratify.dispatchers.StratifyDispatcher
+import kotlinx.coroutines.withContext
+
+class StratifyResolver(private val resolver: Resolver) {
+
+    /**
+     * Use this method to operate on the KSP [Resolver] instance for this symbol processor.
+     * This method ensures that all access to the [Resolver] is done on the main thread, as the [Resolver]
+     * implementation is not inherently thread-safe.
+     */
+    suspend fun <T> use(action: Resolver.() -> T): T = withContext(StratifyDispatcher.Main) {
+        resolver.action()
+    }
+}

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/AnnotationStrategy.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/AnnotationStrategy.kt
@@ -1,8 +1,8 @@
 package io.github.mattshoe.shoebox.stratify.strategy
 
-import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSNode
+import io.github.mattshoe.shoebox.stratify.kspwrappers.StratifyResolver
 import io.github.mattshoe.shoebox.stratify.processor.Processor
 import kotlin.reflect.KClass
 
@@ -16,16 +16,9 @@ data class AnnotationStrategy(
 ): Strategy<KSAnnotated, KSAnnotated> {
     constructor(annotation: KClass<out Annotation>, vararg processors: Processor<KSAnnotated>): this(annotation, processors.toList())
 
-    fun foo(resolver: Resolver, processor: Processor<KSAnnotated>): List<KSAnnotated> {
-        return resolver
-            .getSymbolsWithAnnotation(annotation.qualifiedName!!)
-            .filterIsInstance(processor.targetClass.java)
-            .toList()
-    }
-
-    override fun resolveNodes(resolver: Resolver, processor: Processor<KSNode>): List<KSAnnotated> {
-        return resolver
-            .getSymbolsWithAnnotation(annotation.qualifiedName!!)
-            .toList()
+    override suspend fun resolveNodes(resolver: StratifyResolver, processor: Processor<KSNode>): List<KSAnnotated> {
+        return resolver.use {
+            getSymbolsWithAnnotation(annotation.qualifiedName!!)
+        }.toList()
     }
 }

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/FileNameStrategy.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/FileNameStrategy.kt
@@ -1,24 +1,25 @@
 package io.github.mattshoe.shoebox.stratify.strategy
 
-import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSNode
+import io.github.mattshoe.shoebox.stratify.kspwrappers.StratifyResolver
 import io.github.mattshoe.shoebox.stratify.processor.Processor
 
 /**
  * Defines a [Strategy] whose [processors] will receive all instances of any [KSFile] whose name
  * exactly matches the given [name].
  */
-//data class FileNameStrategy(
-//    val name: String,
-//    override val processors: List<Processor<KSFile>>
-//): Strategy<KSFile> {
-//    constructor(name: String, vararg processors: Processor<KSFile>): this(name, processors.toList())
-//
-//    override fun resolveNodes(resolver: Resolver, processor: Processor<KSFile>): List<KSFile> {
-//        return resolver
-//            .getAllFiles()
-//            .filter {
-//                it.fileName == name
-//            }.toList()
-//    }
-//}
+data class FileNameStrategy(
+    val name: String,
+    override val processors: List<Processor<KSFile>>
+): Strategy<KSFile, KSFile> {
+    constructor(name: String, vararg processors: Processor<KSFile>): this(name, processors.toList())
+
+    override suspend fun resolveNodes(resolver: StratifyResolver, processor: Processor<KSNode>): List<KSFile> {
+        return resolver.use {
+            getAllFiles()
+        }.filter {
+            it.fileName == name
+        }.toList()
+    }
+}

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/FilePatternStrategy.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/FilePatternStrategy.kt
@@ -1,7 +1,8 @@
 package io.github.mattshoe.shoebox.stratify.strategy
 
-import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSNode
+import io.github.mattshoe.shoebox.stratify.kspwrappers.StratifyResolver
 import io.github.mattshoe.shoebox.stratify.processor.Processor
 
 /**
@@ -10,21 +11,20 @@ import io.github.mattshoe.shoebox.stratify.processor.Processor
  *
  * Note that [pattern] is a Regex.
  */
-//data class FilePatternStrategy(
-//    val pattern: String,
-//    override val processors: List<Processor<KSFile>>
-//): Strategy<KSFile> {
-//    constructor(pattern: String, vararg processors: Processor<KSFile>): this(pattern, processors.toList())
-//
-//    private val regex = Regex(pattern)
-//
-//    override fun resolveNodes(resolver: Resolver, processor: Processor<KSFile>): List<KSFile> {
-//        return resolver
-//            .getAllFiles()
-//            .filter {
-//                it::class.java.isAssignableFrom(processor.targetClass.java)
-//                    && it.fileName.matches(regex)
-//            }
-//            .toList()
-//    }
-//}
+data class FilePatternStrategy(
+    val pattern: String,
+    override val processors: List<Processor<KSFile>>
+): Strategy<KSFile, KSFile> {
+    constructor(pattern: String, vararg processors: Processor<KSFile>): this(pattern, processors.toList())
+
+    private val regex = Regex(pattern)
+
+    override suspend fun resolveNodes(resolver: StratifyResolver, processor: Processor<KSNode>): List<KSFile> {
+        return resolver.use {
+            getAllFiles()
+        }.filter {
+            it::class.java.isAssignableFrom(processor.targetClass.java)
+                    && it.fileName.matches(regex)
+        }.toList()
+    }
+}

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/FunctionNameStrategy.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/FunctionNameStrategy.kt
@@ -1,8 +1,9 @@
 package io.github.mattshoe.shoebox.stratify.strategy
 
 import com.google.devtools.ksp.getFunctionDeclarationsByName
-import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSNode
+import io.github.mattshoe.shoebox.stratify.kspwrappers.StratifyResolver
 import io.github.mattshoe.shoebox.stratify.processor.Processor
 
 /**
@@ -14,19 +15,19 @@ import io.github.mattshoe.shoebox.stratify.processor.Processor
  *
  * @param name fully qualified name of the function to be loaded; using '.' as separator.
  */
-//data class FunctionNameStrategy(
-//    val name: String,
-//    override val processors: List<Processor<KSFunctionDeclaration>>
-//): Strategy<KSFunctionDeclaration> {
-//    constructor(name: String, vararg processors: Processor<KSFunctionDeclaration>): this(name, processors.toList())
-//
-//    override fun resolveNodes(
-//        resolver: Resolver,
-//        processor: Processor<KSFunctionDeclaration>
-//    ): List<KSFunctionDeclaration> {
-//        return resolver
-//            .getFunctionDeclarationsByName(name)
-//            .toList()
-//    }
-//}
+data class FunctionNameStrategy(
+    val name: String,
+    override val processors: List<Processor<KSFunctionDeclaration>>
+): Strategy<KSFunctionDeclaration, KSFunctionDeclaration> {
+    constructor(name: String, vararg processors: Processor<KSFunctionDeclaration>): this(name, processors.toList())
+
+    override suspend fun resolveNodes(
+        resolver: StratifyResolver,
+        processor: Processor<KSNode>
+    ): List<KSFunctionDeclaration> {
+        return resolver.use {
+            getFunctionDeclarationsByName(name)
+        }.toList()
+    }
+}
 

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/FunctionPatternStrategy.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/FunctionPatternStrategy.kt
@@ -1,7 +1,8 @@
 package io.github.mattshoe.shoebox.stratify.strategy
 
-import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSNode
+import io.github.mattshoe.shoebox.stratify.kspwrappers.StratifyResolver
 import io.github.mattshoe.shoebox.stratify.processor.Processor
 
 /**
@@ -10,27 +11,25 @@ import io.github.mattshoe.shoebox.stratify.processor.Processor
  *
  * @param pattern regex to match function names.
  */
-//data class FunctionPatternStrategy(
-//    val pattern: String,
-//    override val processors: List<Processor<KSFunctionDeclaration>>
-//): Strategy<KSFunctionDeclaration> {
-//    constructor(name: String, vararg processors: Processor<KSFunctionDeclaration>): this(name, processors.toList())
-//
-//    private val regex = Regex(pattern)
-//
-//    override fun resolveNodes(
-//        resolver: Resolver,
-//        processor: Processor<KSFunctionDeclaration>
-//    ): List<KSFunctionDeclaration> {
-//        return resolver
-//            .getAllFiles()
-//            .flatMap {
-//                it.declarations.filterIsInstance<KSFunctionDeclaration>()
-//            }
-//            .filter {
-//                it.qualifiedName?.asString()?.matches(regex) ?: false
-//            }
-//            .toList()
-//    }
-//}
+data class FunctionPatternStrategy(
+    val pattern: String,
+    override val processors: List<Processor<KSFunctionDeclaration>>
+): Strategy<KSFunctionDeclaration, KSFunctionDeclaration> {
+    constructor(name: String, vararg processors: Processor<KSFunctionDeclaration>): this(name, processors.toList())
+
+    private val regex = Regex(pattern)
+
+    override suspend fun resolveNodes(
+        resolver: StratifyResolver,
+        processor: Processor<KSNode>
+    ): List<KSFunctionDeclaration> {
+        return resolver.use {
+            getAllFiles()
+        }.flatMap {
+            it.declarations.filterIsInstance<KSFunctionDeclaration>()
+        }.filter {
+            it.qualifiedName?.asString()?.matches(regex) ?: false
+        }.toList()
+    }
+}
 

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/NewFilesStrategy.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/NewFilesStrategy.kt
@@ -2,6 +2,8 @@ package io.github.mattshoe.shoebox.stratify.strategy
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSNode
+import io.github.mattshoe.shoebox.stratify.kspwrappers.StratifyResolver
 import io.github.mattshoe.shoebox.stratify.processor.Processor
 
 /**
@@ -11,12 +13,14 @@ import io.github.mattshoe.shoebox.stratify.processor.Processor
  *
  * @see [Resolver.getNewFiles]
  */
-//data class NewFilesStrategy(
-//    override val processors: List<Processor<KSFile>>
-//): Strategy<KSFile> {
-//    constructor(vararg processors: Processor<KSFile>): this(processors.toList())
-//
-//    override fun resolveNodes(resolver: Resolver, processor: Processor<KSFile>): List<KSFile> {
-//        return resolver.getNewFiles().toList()
-//    }
-//}
+data class NewFilesStrategy(
+    override val processors: List<Processor<KSFile>>
+): Strategy<KSFile, KSFile> {
+    constructor(vararg processors: Processor<KSFile>): this(processors.toList())
+
+    override suspend fun resolveNodes(resolver: StratifyResolver, processor: Processor<KSNode>): List<KSFile> {
+        return resolver.use {
+            getNewFiles()
+        }.toList()
+    }
+}

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/PropertyNameStrategy.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/PropertyNameStrategy.kt
@@ -1,7 +1,8 @@
 package io.github.mattshoe.shoebox.stratify.strategy
 
-import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import io.github.mattshoe.shoebox.stratify.kspwrappers.StratifyResolver
 import io.github.mattshoe.shoebox.stratify.processor.Processor
 
 /**
@@ -10,24 +11,22 @@ import io.github.mattshoe.shoebox.stratify.processor.Processor
  *
  * @param name fully qualified name of the function to be loaded; using '.' as separator.
  */
-//data class PropertyNameStrategy(
-//    val name: String,
-//    override val processors: List<Processor<KSPropertyDeclaration>>
-//): Strategy<KSPropertyDeclaration> {
-//    constructor(name: String, vararg processors: Processor<KSPropertyDeclaration>): this(name, processors.toList())
-//
-//    override fun resolveNodes(
-//        resolver: Resolver,
-//        processor: Processor<KSPropertyDeclaration>
-//    ): List<KSPropertyDeclaration> {
-//        return resolver
-//            .getAllFiles()
-//            .flatMap {
-//                it.declarations.filterIsInstance<KSPropertyDeclaration>()
-//            }
-//            .filter {
-//                it.qualifiedName?.asString() == name
-//            }
-//            .toList()
-//    }
-//}
+data class PropertyNameStrategy(
+    val name: String,
+    override val processors: List<Processor<KSPropertyDeclaration>>
+): Strategy<KSPropertyDeclaration, KSPropertyDeclaration> {
+    constructor(name: String, vararg processors: Processor<KSPropertyDeclaration>): this(name, processors.toList())
+
+    override suspend fun resolveNodes(
+        resolver: StratifyResolver,
+        processor: Processor<KSNode>
+    ): List<KSPropertyDeclaration> {
+        return resolver.use {
+            getAllFiles()
+        }.flatMap {
+            it.declarations.filterIsInstance<KSPropertyDeclaration>()
+        }.filter {
+            it.qualifiedName?.asString() == name
+        }.toList()
+    }
+}

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/PropertyPatternStrategy.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/PropertyPatternStrategy.kt
@@ -1,7 +1,8 @@
 package io.github.mattshoe.shoebox.stratify.strategy
 
-import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import io.github.mattshoe.shoebox.stratify.kspwrappers.StratifyResolver
 import io.github.mattshoe.shoebox.stratify.processor.Processor
 
 /**
@@ -10,26 +11,24 @@ import io.github.mattshoe.shoebox.stratify.processor.Processor
  *
  * @param pattern regex to match property names.
  */
-//data class PropertyPatternStrategy(
-//    val pattern: String,
-//    override val processors: List<Processor<KSPropertyDeclaration>>
-//): Strategy<KSPropertyDeclaration> {
-//    constructor(name: String, vararg processors: Processor<KSPropertyDeclaration>): this(name, processors.toList())
-//
-//    private val regex = Regex(pattern)
-//
-//    override fun resolveNodes(
-//        resolver: Resolver,
-//        processor: Processor<KSPropertyDeclaration>
-//    ): List<KSPropertyDeclaration> {
-//        return resolver
-//            .getAllFiles()
-//            .flatMap {
-//                it.declarations.filterIsInstance<KSPropertyDeclaration>()
-//            }
-//            .filter {
-//                it.qualifiedName?.asString()?.matches(regex) ?: false
-//            }
-//            .toList()
-//    }
-//}
+data class PropertyPatternStrategy(
+    val pattern: String,
+    override val processors: List<Processor<KSPropertyDeclaration>>
+): Strategy<KSPropertyDeclaration, KSPropertyDeclaration> {
+    constructor(name: String, vararg processors: Processor<KSPropertyDeclaration>): this(name, processors.toList())
+
+    private val regex = Regex(pattern)
+
+    override suspend fun resolveNodes(
+        resolver: StratifyResolver,
+        processor: Processor<KSNode>
+    ): List<KSPropertyDeclaration> {
+        return resolver.use {
+            getAllFiles()
+        }.flatMap {
+            it.declarations.filterIsInstance<KSPropertyDeclaration>()
+        }.filter {
+            it.qualifiedName?.asString()?.matches(regex) ?: false
+        }.toList()
+    }
+}

--- a/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/Strategy.kt
+++ b/Stratify/src/main/kotlin/io/github/mattshoe/shoebox/stratify/strategy/Strategy.kt
@@ -1,10 +1,10 @@
 package io.github.mattshoe.shoebox.stratify.strategy
 
-import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSNode
+import io.github.mattshoe.shoebox.stratify.kspwrappers.StratifyResolver
 import io.github.mattshoe.shoebox.stratify.processor.Processor
 
 interface Strategy<out TFilter: KSNode, TProcessor: TFilter> {
     val processors: List<Processor<TProcessor>>
-    fun resolveNodes(resolver: Resolver, processor: Processor<KSNode>): List<TFilter>
+    suspend fun resolveNodes(resolver: StratifyResolver, processor: Processor<KSNode>): List<TFilter>
 }

--- a/ci/zip.sh
+++ b/ci/zip.sh
@@ -5,6 +5,8 @@ projects=(
   "Stratify"
 )
 
+set -e
+
 OUTPUT_DIR="./build/distributions/"
 echo "$PWD"
 


### PR DESCRIPTION
- `StratifyDispatcher.Main` - single thread Dispatcher meant to ensure single-thread access to KSP APIs
- Wrapped KSP api's (Resolver, CodeGenerator) with provider classes to enforce that access to KSP api's is ALWAYS done on `StratifyDispatchers.Main`